### PR TITLE
Fixed shortest path on taget searches

### DIFF
--- a/OTAIntfSearch.dpr
+++ b/OTAIntfSearch.dpr
@@ -7,7 +7,7 @@
 
   @Author  David Hoyle
   @Version 1.0
-  @Date    16 Dec 2016
+  @Date    17 Dec 2016
 
 **)
 Program OTAIntfSearch;

--- a/OTAIntfSearch.dproj
+++ b/OTAIntfSearch.dproj
@@ -195,12 +195,27 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployClass Name="ProjectiOSDeviceResourceRules">
+                <DeployClass Name="DependencyModule">
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                        <Extensions>.dll;.bpl</Extensions>
+                    </Platform>
                     <Platform Name="iOSDevice64">
                         <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
                     </Platform>
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="ProjectOSXResource">
@@ -579,27 +594,12 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <DeployClass Name="DependencyModule">
-                    <Platform Name="Win32">
-                        <Operation>0</Operation>
-                        <Extensions>.dll;.bpl</Extensions>
-                    </Platform>
+                <DeployClass Name="ProjectiOSDeviceResourceRules">
                     <Platform Name="iOSDevice64">
                         <Operation>1</Operation>
-                        <Extensions>.dylib</Extensions>
-                    </Platform>
-                    <Platform Name="OSX32">
-                        <RemoteDir>Contents\MacOS</RemoteDir>
-                        <Operation>1</Operation>
-                        <Extensions>.dylib</Extensions>
                     </Platform>
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
-                        <Extensions>.dylib</Extensions>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                        <Extensions>.dylib</Extensions>
                     </Platform>
                 </DeployClass>
                 <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>

--- a/OTAIntfSearchITHVerInfo.RC
+++ b/OTAIntfSearchITHVerInfo.RC
@@ -1,8 +1,8 @@
 LANGUAGE LANG_ENGLISH,SUBLANG_ENGLISH_US
 
 1 VERSIONINFO LOADONCALL MOVEABLE DISCARDABLE IMPURE
-FILEVERSION 1, 1, 0, 488
-PRODUCTVERSION 1, 1, 0, 488
+FILEVERSION 1, 1, 0, 491
+PRODUCTVERSION 1, 1, 0, 491
 FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 FILEOS VOS__WINDOWS32
 FILETYPE VFT_APP
@@ -13,7 +13,7 @@ FILETYPE VFT_APP
     {
      VALUE "CompanyName", "Season's Fall Music\000"
      VALUE "FileDescription", "OTAIntfSearch: An application to allow you to search interfaces / classes and method properties for matching text.\000"
-     VALUE "FileVersion", "1.1.0.488\000"
+     VALUE "FileVersion", "1.1.0.491\000"
      VALUE "InternalName", "OTAIntfSearch\000"
      VALUE "LegalCopyright", "Season's Fall Music\000"
      VALUE "LegalTrademarks", "Season's Fall Music\000"

--- a/Source/OTAIntfSearch.GenerateOTACode.pas
+++ b/Source/OTAIntfSearch.GenerateOTACode.pas
@@ -572,7 +572,8 @@ Begin
   If Result Then
     Begin
       P := AddNode(ParentNode, FFileIndex, iParentInterface, 0, ltBorlandIDEServices);
-      FOISTargetSearchPaths.AddServicePath(P);
+      If Not FTargeting Then
+        FOISTargetSearchPaths.AddServicePath(P);
     End;
 End;
 


### PR DESCRIPTION
Fixed the shortest path for a target search not working due to the inclusion of service paths.